### PR TITLE
Fix header blocking content on mobile, make mobile header font smaller

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -12,12 +12,11 @@ body {
     /* color: #383838; */
     color: #e1e1e1;
     background-color: #121212;
-    padding-top: 60px;
 }
 
 header.site-header {
     background-color: #121212;
-    position: fixed;
+    position: sticky;
     top: 0;
 }
 
@@ -159,6 +158,12 @@ h3 a:hover, h3 a:active {
     }
 }
 
+@media only screen and (max-width: 768px) {
+    .site-title {
+        font-size: 20px !important;
+        padding: 0;
+    }
+}
 
 /* hide TOC when printing */
 @media print


### PR DESCRIPTION
In header styles, forcing the position of the header made it so that it blocked some content when using the website on mobile:
![image](https://github.com/user-attachments/assets/fdeb641e-7b04-4d06-b506-dbbfac975a11)

The font was also too big for mobile, so made that smaller:
![image](https://github.com/user-attachments/assets/824cca4d-cc10-46e0-a1b3-a8556b197232)
